### PR TITLE
Bug 907711 Add Japanese fonts

### DIFF
--- a/fonts.mk
+++ b/fonts.mk
@@ -26,6 +26,8 @@ PRODUCT_COPY_FILES += \
     frameworks/base/data/fonts/DroidSerif-Bold.ttf:system/fonts/DroidSerif-Bold.ttf \
     frameworks/base/data/fonts/DroidSerif-Italic.ttf:system/fonts/DroidSerif-Italic.ttf \
     frameworks/base/data/fonts/DroidSerif-BoldItalic.ttf:system/fonts/DroidSerif-BoldItalic.ttf \
+    frameworks/base/data/fonts/MTLmr3m.ttf:system/fonts/MTLmr3m.ttf \
+    frameworks/base/data/fonts/MTLc3m.ttf:system/fonts/MTLc3m.ttf \
     $(NULL)
 
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Use motoya fonts which are preferred Japanese fonts on Firefox for Android

Since glyph forms of CJK ideographs are varied depending languages, it is important for Japanese users to include fonts which have Japanese glyph form on B2G.

Some of  variant forms are listed in 
http://en.wikipedia.org/wiki/Variant_Chinese_character#Usage_in_computing

I've tested the patch on Peak

FYI: Bug 716233 makes motoya fonts preferred Japanese fonts on Firefox for Android
https://bugzilla.mozilla.org/show_bug.cgi?id=716233
